### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,12 @@
     <artifactId>protobuf-generator</artifactId>
     <version>0.3.9</version>
 
+    <scm>
+           <connection>scm:git:git://github.com/liquibase/protobuf-generator.git</connection>
+           <developerConnection>scm:git:ssh://github.com:liquibase/protobuf-generator.git</developerConnection>
+           <url>https://github.com/liquibase/protobuf-generator</url>
+    </scm>
+         
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
fix: `pom.xml`: add scm block for error:
`Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project protobuf-generator: Missing required setting: scm connection or developerConnection must be specified`

https://github.com/liquibase/protobuf-generator/actions/runs/11256052312/job/31297314383#step:12:400